### PR TITLE
Use the actual Fisher-Yates shuffle.

### DIFF
--- a/src/Random.hx
+++ b/src/Random.hx
@@ -54,16 +54,15 @@ class Random
 	}
 
 	/** Shuffle an Array.  This operation affects the array in place, and returns that array.
-		The shuffle algorithm used is a variation of the [Fisher Yates Shuffle](http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle) */
+		The shuffle algorithm used is the [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle) */
 	public static function shuffle<T>(arr:Array<T>):Array<T>
 	{
 		if (arr!=null) {
-			for (i in 0...arr.length) {
-				var j = int(0, arr.length - 1);
-				var a = arr[i];
-				var b = arr[j];
-				arr[i] = b;
-				arr[j] = a;
+			for (i in 0...(arr.length - 1)) {
+				var j = int(i, arr.length - 1);
+				var temp = arr[i];
+				arr[i] = arr[j];
+				arr[j] = temp;
 			}
 		}
 		return arr;


### PR DESCRIPTION
Your implementation does technically show up on the Wikipedia page, but unfortunately, it shows up under "[implementation errors](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#Implementation_errors)":

> always selecting j from the entire range of valid array indices on every iteration also produces a result which is biased, albeit less obviously so.

I've modified it to match the second example listed under "[the modern algorithm](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm)."